### PR TITLE
Fix root shell leaking after MainActivity stop

### DIFF
--- a/app/src/main/java/com/isaacparker/dozesettingseditor/MainActivity.java
+++ b/app/src/main/java/com/isaacparker/dozesettingseditor/MainActivity.java
@@ -796,6 +796,11 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStop() {
         Profiles.saveUserProfiles(sharedPref, gson);
+        try { // close root shell before exiting app
+            RootShell.closeAllShells();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
         super.onStop();
     }
 


### PR DESCRIPTION
When the MainActivity is stopped, the root shell gets leaked outside the activity lifecycle. Additional side-effect: on roms or apps that show root-in-use, the indicator will stay visible forever.